### PR TITLE
fix resetToInitialState bug

### DIFF
--- a/frontend/src/lib/game-of-life/domain/entities/Board.ts
+++ b/frontend/src/lib/game-of-life/domain/entities/Board.ts
@@ -116,6 +116,20 @@ export class Board {
     return this.currentHistoryIndex === this.history.length - 1;
   }
 
+  resetToInitialState(): void {
+    // Go back to the first state and clear future history
+    if (this.history.length > 0) {
+      const initialState = this.history[0];
+      this.cells.clear();
+      initialState.forEach((cell, key) => {
+        this.cells.set(key, new Cell(cell.x, cell.y, true));
+      });
+      // Keep only the initial state in history
+      this.history = [initialState];
+      this.currentHistoryIndex = 0;
+    }
+  }
+
   undo(): void {
     if (!this.canUndo()) return;
 

--- a/frontend/src/lib/game-of-life/hooks/useGameOfLife.ts
+++ b/frontend/src/lib/game-of-life/hooks/useGameOfLife.ts
@@ -104,12 +104,9 @@ export function useGameOfLife(options: UseGameOfLifeOptions) {
   }, [board, updateCells]);
 
   const resetToInitial = useCallback(() => {
-    // Go back to generation 0 without clearing
+    // Go back to generation 0 and clear future history
     if (board.hasInitialState()) {
-      // Reset to the first state in history
-      while (board.canUndo()) {
-        board.undo();
-      }
+      board.resetToInitialState();
       setGeneration(0);
       updateCells();
     }


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
fixed bug where the reset to initial state would not clear the history 

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
when reseting the board to the initial state, clear the history as well 

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.
-->
tested it locally 
